### PR TITLE
Voxels enclosed within Isosurface calculation

### DIFF
--- a/src/property/hnd_elpiso.F
+++ b/src/property/hnd_elpiso.F
@@ -200,11 +200,14 @@ C
 
 
 C Returns the coordinates of grid points that lie within a TOLERANCE,
-C on electron density isosurface of value ISOVALUE
+C on electron density isosurface of value ISOVALUE.
+C Also calculates the number of voxels enclosed within the 
+C isosurface, storing this in the rtdb as prop:epsiso:nenc.
 C
 C ISOVALUE == 0.002 ~ Vdw radius
 C
 C Mark J. Williamson Summer 2015
+C Mark D. Driver Spring 2018
 C
       subroutine get_points_from_iso(rtdb, basis, geom, isovalue,
      > tolerance, sub_nprp, i_sub_prp_c)

--- a/src/property/hnd_elpiso.F
+++ b/src/property/hnd_elpiso.F
@@ -224,7 +224,7 @@ C
       integer sub_nprp            ! [Output] Number of points lying on this surface
       integer h_sub_prp_c         ! Memhandle to points lying on the iso surface
       integer i_sub_prp_c         ! [Output] Index to points lying on this surface
-
+      integer sub_nprp_enc   ! [Output] Number of points lying within surface
       integer i,j,n,nat,iat
       integer g_dens(3)      ! Handle to density
       integer ndens          ! Number of active density handles (RHF=1, UHF=3)
@@ -288,14 +288,23 @@ C nder=-1; compute the 1-electron density
       call hnd_elfcon(basis,geom,g_dens(ndens),dbl_mb(i_prp_c),nprp, 
      & dbl_mb(i_eden),-1)
 
+C Work out how many points lie within the given iso surface (sub_nprp_enc).
 C Scan ahead and work out how many points (sub_nprp) lie on the isosurface
       sub_nprp = 0
+      sub_nprp_enc = 0
       do i=1, nprp
+        if (dbl_mb(i_eden + (i-1)) > isovalue) then
+          sub_nprp_enc = sub_nprp_enc + 1
+        end if
         if ( abs(dbl_mb(i_eden + (i-1)) - isovalue) < tolerance ) then
           sub_nprp = sub_nprp + 1
         end if
       end do
 
+C Store number of points enclosed by surface in rtdb.
+      if (.not. rtdb_put(rtdb, 'prop:epsiso:nenc', mt_int, 1,
+     &                   sub_nprp_enc))
+     &      call errquit('prop_input: rtdb_put failed', 0, RTDB_ERR)
 C Allocate array for storing the location of these points
       if(.not.ma_alloc_get(MT_DBL, 3*sub_nprp, 'hnd_elpiso grid array',
      &      h_sub_prp_c, i_sub_prp_c) ) call errquit(

--- a/src/property/prop_grid.F
+++ b/src/property/prop_grid.F
@@ -56,7 +56,7 @@ c     recalculate step
       if(ga_nodeid().eq.0) then
       buffer = "PARAMETERS of gaussian cube file"
       call util_print_centered(luout, trim(buffer),.true., .true.)
-      WRITE(*,'(1X,A,T12,":",3F12.3)') "step (Ang)",step
+      WRITE(*,'(1X,A,T12,":",3F12.3)') "step (Ang)",step*cau2ang
       write(*,'(1X,A,T12,":",3I4)') "ngrid",ngrid
       write(*,'(1X,A,T12,":",I9)') "npoints",npoints
       write(*,'(1X,A,T12,":",3(F12.3,4X))') "rmax (Ang)",rmax*cau2ang


### PR DESCRIPTION
This contains functionality to calculate the number of voxels enclosed by an isosurface when calculating the isosurface. This number is then stored in the rtdb.

There is also a logging update, to correct the output value to match the units stated (in 
e66ec72).